### PR TITLE
Fix the github repo url in sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ description: >-                        # used by seo meta and the atom feed
 url: 'https://www.satdump.org'
 
 github:
-  username: Altillimity/SatDump             # change to your github username
+  username: SatDump/SatDump             # change to your github username
 
 #twitter:
 #  username: twitter_username            # change to your twitter username


### PR DESCRIPTION
From the (I assume) prev `Altillimity/SatDump`, to current `SatDump/SatDump`